### PR TITLE
chore: fix invalid `paths_ignore` and docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ on:
     branches:
       - main
     types: [opened, synchronize]
-    paths_ignore:
+    paths-ignore:
       - "*.md"
       - "*.json"
   push:
     branches:
       - main
-    paths_ignore:
+    pathsignore:
       - "*.md"
       - "*.json"
 
@@ -48,7 +48,7 @@ jobs:
       - uses: oxc-project/oxlint-action@latest
         with:
           # Allow, Warn, or Deny specific lint rules or entire categories
-          # https://oxc.rs/docs/guide/usage/linter/cli.html#enable-plugins
+          # https://oxc.rs/docs/guide/usage/linter/cli.html#allowing-denying-multiple-lints
           deny: |
             correctness
             no-eval


### PR DESCRIPTION
- `paths_ignore` is invalid key, `paths-ignore` is valid

reference: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore

---

- change miss-linked docs url to `allow-deny` docs

```suggestion
- https://oxc.rs/docs/guide/usage/linter/cli.html#enable-plugins
+ https://oxc.rs/docs/guide/usage/linter/cli.html#allowing-denying-multiple-lints
```
