### PR TITLE
fix replace string for process multiple keys

### DIFF
--- a/oxlint.sh
+++ b/oxlint.sh
@@ -23,13 +23,13 @@ OXLINT_ARGS="$config"
 # Build plugin args
 # map whitespace-separated `name` to `--name-plugin`
 if [ -n "$OXLINT_PLUGINS" ]; then
-    plugins="$(echo "$OXLINT_PLUGINS" | xargs | sed -e 's/ / --/g' -e 's/^/--/')-plugin"
+    plugins="$(echo "$OXLINT_PLUGINS" | xargs | sed -e 's/ / --plugin-/g' -e 's/^/--plugin-/')"
 fi
 
 # build disable plugin args
 # map whitespace-separated `name` to `--disable-name-plugin`
 if [ -n "$OXLINT_PLUGINS_DISABLE" ]; then
-    disable_plugins="$(echo "$OXLINT_PLUGINS_DISABLE" | xargs | sed -e 's/ / --disable-/g' -e 's/^/--disable-/')-plugin"
+    disable_plugins="$(echo "$OXLINT_PLUGINS_DISABLE" | xargs | sed -e 's/ /-plugin --disable-/g' -e 's/^/--disable-/')-plugin"
 fi
 
 OXLINT_ARGS="$OXLINT_ARGS $plugins $disable_plugins"

--- a/oxlint.sh
+++ b/oxlint.sh
@@ -23,7 +23,7 @@ OXLINT_ARGS="$config"
 # Build plugin args
 # map whitespace-separated `name` to `--name-plugin`
 if [ -n "$OXLINT_PLUGINS" ]; then
-    plugins="$(echo "$OXLINT_PLUGINS" | xargs | sed -e 's/ / --plugin-/g' -e 's/^/--plugin-/')"
+    plugins="$(echo "$OXLINT_PLUGINS" | xargs | sed -e 's/ /-plugin --/g' -e 's/^/--/')-plugin"
 fi
 
 # build disable plugin args


### PR DESCRIPTION
`oxlint.sh` looks not work with multiple `$OXLINT_PLUGINS` or `$OXLINT_PLUGINS_DISABLE` currently.
this pr will allow multiple keys for `$OXLINT_PLUGINS` and `$OXLINT_PLUGINS_DISABLE`
(pretty ugly replace, but it works)

##### tested on local zsh
```sh
echo "$(echo "react react2" | xargs | sed -e 's/ / --/g' -e 's/^/--/')-plugin"
# --react --react2-plugin

echo "$(echo "react react2" | xargs | sed -e 's/ / --disable-/g' -e 's/^/--disable-/')-plugin"
# --disable-react --disable-react2-plugin
```


```sh
echo "$(echo "react react2" | xargs | sed -e 's/ /-plugin --/g' -e 's/^/--/')-plugin"
# --react-plugin --react2-plugin

echo "$(echo "react react2" | xargs | sed -e 's/ /-plugin --disable-/g' -e 's/^/--disable-/')-plugin"
# --disable-react-plugin --disable-react2-plugin
```