### PR TITLE
feat: add working-directory support for monorepos

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ This action lints your JS/TS codebase with
 [Oxlint][oxc-github-url] and attaches reported issues as
 annotations. Pull requests will only have their changed files linted by default.
 
+For monorepos, you can use the `working-directory` input to lint only a specific subdirectory.
+
 
 ## ⚡ Quick Start
 Here's a minimal example to get you started:
@@ -114,6 +116,10 @@ jobs:
         # pattern. This gets forwarded to npx. By default, 'latest' is used.
         # See: https://www.npmjs.com/package/oxlint
         version: latest
+
+        # Specify a working directory to run oxlint in. Useful for monorepos
+        # where you want to lint only a specific subdirectory.
+        working-directory: frontend
 ```
 
 [oxc-stars-badge]: https://img.shields.io/github/stars/oxc-project/oxc?style=social

--- a/action.yml
+++ b/action.yml
@@ -60,6 +60,11 @@ inputs:
     required: false
     default: ""  # Default to PR target branch
 
+  working-directory:
+    description: "Working directory to run oxlint in."
+    required: false
+    default: ""
+
 runs:
   using: "composite"
   steps:
@@ -96,9 +101,10 @@ runs:
     - name: Run Oxlint (Changed Files)
       shell: bash
       if: github.event_name == 'pull_request' && inputs.all-files == 'false'
+      working-directory: ${{ inputs.working-directory }}
       run: |
         echo "::group::Run Oxlint (Changed Files)"
-        files=$(git diff --name-only ${{ steps.base-branch.outputs.base-branch }} ${{ github.sha }})
+        files=$(git diff --name-only --relative ${{ steps.base-branch.outputs.base-branch }} ${{ github.sha }})
         echo "::debug::Files:"
         echo "::debug::${files}"
         $GITHUB_ACTION_PATH/oxlint.sh $files
@@ -117,6 +123,7 @@ runs:
     - name: Run Oxlint (All Files)
       shell: bash
       if: github.event_name != 'pull_request' || inputs.all-files == 'true'
+      working-directory: ${{ inputs.working-directory }}
       run: |
         echo "::group::Run Oxlint (All Files)"
         $GITHUB_ACTION_PATH/oxlint.sh


### PR DESCRIPTION
## Summary
- Added `working-directory` input parameter to allow linting specific subdirectories in monorepos
- Uses git's `--relative` flag for proper file path handling when filtering changed files in PRs
- Updated documentation with usage examples

## Implementation
- Added optional `working-directory` input to action.yml  
- Modified both "Changed Files" and "All Files" steps to use step-level working directory
- Simplified git diff logic using `--relative` flag for automatic filtering and path conversion

Resolves #11

🤖 Generated with [Claude Code](https://claude.ai/code)