### PR TITLE
fix!: remove default -W correctness to respect config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ jobs:
         config: .oxlintrc.json
 
         # allow/warn/deny all take a whitespace separate list of categories or
-        # rules to allow, warn or deny. By default, only violations for rules in
-        # the "correctness" category be warned.
+        # rules to allow, warn or deny. If not specified, oxlint will use the
+        # configuration from your config file, or oxlint's defaults.
         # See https://oxc.rs/docs/guide/usage/linter/cli.html#allowing-denying-multiple-lints
         # for a list of categories and rules.
         allow: |

--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ inputs:
   warn:
     description: "Categories and lints to warn about, separated by whitespace"
     required: false
-    default: "correctness"
+    default: ""
 
   max-warnings:
     description: "Maximum number of warnings allowed. By default, no maximum is enforced."

--- a/oxlint.sh
+++ b/oxlint.sh
@@ -42,8 +42,6 @@ fi
 
 if [ -n "$OXLINT_WARN" ]; then
     warn_list="$(echo "$OXLINT_WARN" | xargs | sed -e 's/ / -W /g' -e 's/^/-W /')"
-else
-    warn_list="-W correctness"
 fi
 
 if [ -n "$OXLINT_DENY" ]; then


### PR DESCRIPTION
Fixes #14

Extended Description:

The action no longer applies `-W correctness` by default.

Previously, the action would always apply `-W correctness` when no `warn` input was specified, which caused two issues:

1. Config file settings were ignored - users with `.oxlintrc.json` files that set `"correctness": "error"` would have their configuration overridden by the action's default `-W correctness` flag.

2. Inconsistent behavior between local and CI - running `oxlint` locally would respect the config file, but the GitHub Action would produce different results.

This change makes the action's behavior consistent with the oxlint CLI:
- When no `warn` input is provided, no `-W` flags are passed to oxlint
- Configuration files are now properly respected
- Local and CI environments produce identical results

Migration: Users who relied on the implicit `-W correctness` default and don't have a config file should explicitly add `warn: correctness` to their workflow:

```yaml
- uses: oxc-project/oxlint-action@v3
  with:
    warn: correctness
