### PR TITLE
ci: add security analysis workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,4 +20,4 @@ jobs:
 
       - uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # 2.0.0
 
-      - uses: oxc-project/oxlint-action@92eec2c4d5dbbb882c926478438aa4b7f20ffe2d # v3.0.0
+      - uses: ./

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -5,12 +5,12 @@ on:
   pull_request:
     types: [opened, synchronize]
     paths:
-      - '.github/workflows/**'
+      - ".github/workflows/**"
   push:
     branches:
       - main
     paths:
-      - '.github/workflows/**'
+      - ".github/workflows/**"
 
 permissions: {}
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,26 @@
+name: Security Analysis
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - '.github/workflows/**'
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/**'
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.ref_name != 'main' }}
+
+jobs:
+  security:
+    name: Security Analysis
+    runs-on: ubuntu-latest
+    steps:
+      - uses: oxc-project/security-action@fbbd523b1e765ceb174cb819b92c453bb1da265e # v1.0.0

--- a/action.yml
+++ b/action.yml
@@ -72,12 +72,15 @@ runs:
       id: base-branch
       shell: bash
       if: github.event_name == 'pull_request'
+      env:
+        BASE_BRANCH_INPUT: ${{ inputs.base-branch }}
+        PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
       run: |
-        if [ -z "${{ inputs.base-branch }}" ]; then
+        if [ -z "$BASE_BRANCH_INPUT" ]; then
           echo "Base branch not set. Defaulting to target branch of PR."
-          echo "base-branch=${{ github.event.pull_request.base.ref }}" >> "$GITHUB_OUTPUT"
+          echo "base-branch=$PR_BASE_REF" >> "$GITHUB_OUTPUT"
         else
-          echo "base-branch=${{ inputs.base-branch }}" >> "$GITHUB_OUTPUT"
+          echo "base-branch=$BASE_BRANCH_INPUT" >> "$GITHUB_OUTPUT"
         fi
 
     - name: Fetch Base Branch

--- a/oxlint.sh
+++ b/oxlint.sh
@@ -66,8 +66,29 @@ OXLINT_ARGS="$OXLINT_ARGS --format github"
 
 echo "::debug::Args: $OXLINT_ARGS"
 
+if [ "$#" -gt 0 ]; then
+    lintable_files=()
+    for file in "$@"; do
+        if [ ! -f "$file" ]; then
+            continue
+        fi
+
+        case "$file" in
+            *.js|*.jsx|*.mjs|*.cjs|*.ts|*.tsx|*.mts|*.cts|*.vue|*.astro|*.svelte)
+                lintable_files+=("$file")
+                ;;
+        esac
+    done
+
+    if [ "${#lintable_files[@]}" -eq 0 ]; then
+        echo "No supported files changed. Skipping oxlint."
+        exit 0
+    fi
+
+    set -- "${lintable_files[@]}"
+fi
 
 # Files to lint are passed as arguments. For non-prs, no arguments are passed,
 # which defaults to all VCS files.
-# shellcheck disable=SC2068,SC2086
-npx oxlint@$OXLINT_VERSION $OXLINT_ARGS ${@:1}
+# shellcheck disable=SC2086
+npx oxlint@$OXLINT_VERSION $OXLINT_ARGS "$@"


### PR DESCRIPTION
## Summary
- add the canonical Security Analysis workflow using `oxc-project/security-action`
- replace legacy zizmor workflow files where present

## Testing
- Not run; workflow-only change.
