### PR TITLE
fix: typo in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ jobs:
         plugins-disable: react
 
         # By default, oxlint-action will only lint changed files when run on
-        # pull requests. To disable this behavior, set this to false.
+        # pull requests. To disable this behavior, set this to true.
         # Note that this setting has no affect on any other kind of trigger.
         all-files: false
 


### PR DESCRIPTION
By default, all-files is false and it indicates to run lint only on the changed files. 

If we want to disable this behavior (and thus making it to run on all files), we have to set it as **true**.